### PR TITLE
Add photon vision

### DIFF
--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -5,16 +5,13 @@
 package frc.robot;
 
 import com.revrobotics.CANSparkBase.IdleMode;
-
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
-
 import java.util.function.BooleanSupplier;
-
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 /**
@@ -311,12 +308,16 @@ public final class Constants {
     public static final double TRAP_SCORE_ROTATIONS = 0; // TODO: TUNE
   }
 
-  public static final class PHOTON_VISION{
+  public static final class PHOTON_VISION {
+    public static final AprilTagFieldLayout APRIL_TAG_FIELD_LAYOUT =
+        AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+    public static final PoseStrategy POSE_STRATEGY = PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR;
+  }
+
+  public static final class SHOOTER_PHOTON_CAMERA {
     public static final int NEURAL_NETWORK_PIPELINE = 0;
     public static final int RETROREFLECTIVE_PIPELINE = 1;
-
-    public static final AprilTagFieldLayout APRIL_TAG_FIELD_LAYOUT = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
-    public static final PoseStrategy POSE_STRATEGY = PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR;
-    public static final Transform3d ROBOT_TO_CAMERA_TRANSFORM = new Transform3d(new Translation3d(0, 0, 0), new Rotation3d(0, 0, 0));
+    public static final Transform3d ROBOT_TO_CAMERA_TRANSFORM =
+        new Transform3d(new Translation3d(0, 0, 0), new Rotation3d(0, 0, 0));
   }
 }

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -315,8 +315,11 @@ public final class Constants {
   }
 
   public static final class SHOOTER_PHOTON_CAMERA {
+    public static final String NAME = "ov9782-shooter";
+
     public static final int NEURAL_NETWORK_PIPELINE = 0;
     public static final int RETROREFLECTIVE_PIPELINE = 1;
+
     public static final Transform3d ROBOT_TO_CAMERA_TRANSFORM =
         new Transform3d(new Translation3d(0, 0, 0), new Rotation3d(0, 0, 0));
   }

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -317,8 +317,13 @@ public final class Constants {
   public static final class SHOOTER_PHOTON_CAMERA {
     public static final String NAME = "ov9782-shooter";
 
-    public static final int NEURAL_NETWORK_PIPELINE = 0;
-    public static final int RETROREFLECTIVE_PIPELINE = 1;
+    public static final int APRIL_TAG_PIPELINE = 0;
+    public static final int NEURAL_NETWORK_PIPELINE = 1;
+    public static final int RETROREFLECTIVE_PIPELINE = 2;
+
+    public static final int DEFAULT_PIPELINE = 0;
+
+    public static final double HEAD_ON_TOLERANCE = 0;
 
     public static final Transform3d ROBOT_TO_CAMERA_TRANSFORM =
         new Transform3d(new Translation3d(0, 0, 0), new Rotation3d(0, 0, 0));

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -5,8 +5,17 @@
 package frc.robot;
 
 import com.revrobotics.CANSparkBase.IdleMode;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+
 import java.util.function.BooleanSupplier;
+
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -300,5 +309,14 @@ public final class Constants {
     public static final double PRELOAD_ROTATIONS = 0; // TODO: TUNE
     public static final double AMP_SCORE_ROTATIONS = 0; // TODO: TUNE
     public static final double TRAP_SCORE_ROTATIONS = 0; // TODO: TUNE
+  }
+
+  public static final class PHOTON_VISION{
+    public static final int NEURAL_NETWORK_PIPELINE = 0;
+    public static final int RETROREFLECTIVE_PIPELINE = 1;
+
+    public static final AprilTagFieldLayout APRIL_TAG_FIELD_LAYOUT = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+    public static final PoseStrategy POSE_STRATEGY = PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR;
+    public static final Transform3d ROBOT_TO_CAMERA_TRANSFORM = new Transform3d(new Translation3d(0, 0, 0), new Rotation3d(0, 0, 0));
   }
 }

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -19,6 +19,7 @@ import frc.robot.subsystems.ExtensionArm;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.PhotonVision;
 import frc.robot.subsystems.Shooter;
+import frc.robot.subsystems.ShooterPhotonCamera;
 import frc.robot.subsystems.ShooterPivot;
 
 /**
@@ -60,9 +61,10 @@ public class Robot extends TimedRobot {
     // autonomous chooser on the dashboard.
 
     shooterPhotonCamera =
-        new PhotonVision(
+        new ShooterPhotonCamera(
             Constants.SHOOTER_PHOTON_CAMERA.NAME,
-            Constants.SHOOTER_PHOTON_CAMERA.ROBOT_TO_CAMERA_TRANSFORM);
+            Constants.SHOOTER_PHOTON_CAMERA.ROBOT_TO_CAMERA_TRANSFORM,
+            Constants.SHOOTER_PHOTON_CAMERA.HEAD_ON_TOLERANCE);
 
     state = new RobotState();
 
@@ -95,6 +97,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
+    shooterPhotonCamera.fetchResult();
+
     // Runs the Scheduler. This is responsible for polling buttons, adding
     // newly-scheduled
     // commands, running already-scheduled commands, removing finished or

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -17,7 +17,7 @@ import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.EndAffector;
 import frc.robot.subsystems.ExtensionArm;
 import frc.robot.subsystems.Intake;
-import frc.robot.subsystems.Limelight;
+import frc.robot.subsystems.PhotonVision;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.ShooterPivot;
 
@@ -43,7 +43,7 @@ public class Robot extends TimedRobot {
   public static DriverControls driverControls;
   public static CodriverControls codriverControls;
 
-  public static Limelight shooterLimelight;
+  public static PhotonVision shooterPhotonCamera;
 
   public static EndAffector endAffector;
 
@@ -58,6 +58,12 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer. This will perform all our button bindings,
     // and put our
     // autonomous chooser on the dashboard.
+
+    shooterPhotonCamera =
+        new PhotonVision(
+            Constants.SHOOTER_PHOTON_CAMERA.NAME,
+            Constants.SHOOTER_PHOTON_CAMERA.ROBOT_TO_CAMERA_TRANSFORM);
+
     state = new RobotState();
 
     swerve = TunerConstants.DriveTrain;
@@ -67,8 +73,6 @@ public class Robot extends TimedRobot {
     climber = new Climber();
     endAffector = new EndAffector();
     extensionArm = new ExtensionArm();
-
-    shooterLimelight = new Limelight(Constants.SHOOTER_LIMELIGHT.NAME);
 
     driverControls =
         new DriverControls(

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -44,7 +44,7 @@ public class Robot extends TimedRobot {
   public static DriverControls driverControls;
   public static CodriverControls codriverControls;
 
-  public static PhotonVision shooterPhotonCamera;
+  public static PhotonVision shooterCam;
 
   public static EndAffector endAffector;
 
@@ -60,7 +60,7 @@ public class Robot extends TimedRobot {
     // and put our
     // autonomous chooser on the dashboard.
 
-    shooterPhotonCamera =
+    shooterCam =
         new ShooterPhotonCamera(
             Constants.SHOOTER_PHOTON_CAMERA.NAME,
             Constants.SHOOTER_PHOTON_CAMERA.ROBOT_TO_CAMERA_TRANSFORM,
@@ -97,7 +97,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
-    shooterPhotonCamera.updateResult();
+    shooterCam.updateResult();
 
     // Runs the Scheduler. This is responsible for polling buttons, adding
     // newly-scheduled

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -97,7 +97,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
-    shooterPhotonCamera.fetchResult();
+    shooterPhotonCamera.updateResult();
 
     // Runs the Scheduler. This is responsible for polling buttons, adding
     // newly-scheduled

--- a/robotbase/src/main/java/frc/robot/commands/drive/DriveToApriltag.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/DriveToApriltag.java
@@ -33,7 +33,7 @@ public class DriveToApriltag extends Command {
 
   @Override
   public void initialize() {
-    Robot.shooterPhotonCamera.setPipeline(m_pipelineIndex);
+    Robot.shooterCam.setPipeline(m_pipelineIndex);
 
     // reset pids
     m_yController.setSetpoint(m_tyOffset + Constants.SWERVE.APRILTAG_TY_MAGIC_OFFSET);
@@ -52,14 +52,14 @@ public class DriveToApriltag extends Command {
 
   @Override
   public void execute() {
-    if (!m_canSeePieceDebouncer.calculate(Robot.shooterPhotonCamera.validTargetExists())) {
+    if (!m_canSeePieceDebouncer.calculate(Robot.shooterCam.validTargetExists())) {
       System.out.println("No Target Detected");
       Robot.swerve.drive(0, 0, 0);
       return;
     }
 
-    double tx = Robot.shooterPhotonCamera.getTX();
-    double ty = Robot.shooterPhotonCamera.getTY();
+    double tx = Robot.shooterCam.getTX();
+    double ty = Robot.shooterCam.getTY();
     double rotationError = Robot.swerve.getPose().getRotation().getRadians();
 
     // Increase tx tolerance when close to target since tx is more sensitive at

--- a/robotbase/src/main/java/frc/robot/commands/drive/DriveToApriltag.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/DriveToApriltag.java
@@ -33,7 +33,7 @@ public class DriveToApriltag extends Command {
 
   @Override
   public void initialize() {
-    Robot.shooterLimelight.setPipeline(m_pipelineIndex);
+    Robot.shooterPhotonCamera.setPipeline(m_pipelineIndex);
 
     // reset pids
     m_yController.setSetpoint(m_tyOffset + Constants.SWERVE.APRILTAG_TY_MAGIC_OFFSET);
@@ -52,14 +52,14 @@ public class DriveToApriltag extends Command {
 
   @Override
   public void execute() {
-    if (!m_canSeePieceDebouncer.calculate(Robot.shooterLimelight.validTargetExists())) {
+    if (!m_canSeePieceDebouncer.calculate(Robot.shooterPhotonCamera.validTargetExists())) {
       System.out.println("No Target Detected");
       Robot.swerve.drive(0, 0, 0);
       return;
     }
 
-    double tx = Robot.shooterLimelight.getTX();
-    double ty = Robot.shooterLimelight.getTY();
+    double tx = Robot.shooterPhotonCamera.getTX();
+    double ty = Robot.shooterPhotonCamera.getTY();
     double rotationError = Robot.swerve.getPose().getRotation().getRadians();
 
     // Increase tx tolerance when close to target since tx is more sensitive at

--- a/robotbase/src/main/java/frc/robot/commands/drive/DriveToGamepeice.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/DriveToGamepeice.java
@@ -14,12 +14,12 @@ public class DriveToGamepeice extends Command {
   private Pose2d m_initialPose;
 
   public DriveToGamepeice() {
-    addRequirements(Robot.swerve, Robot.shooterLimelight);
+    addRequirements(Robot.swerve, Robot.shooterPhotonCamera);
   }
 
   @Override
   public void initialize() {
-    Robot.shooterLimelight.setPipeline(SHOOTER_LIMELIGHT.GAMEPIECE_INDEX);
+    Robot.shooterPhotonCamera.setPipeline(SHOOTER_LIMELIGHT.GAMEPIECE_INDEX);
     Robot.state.setDriveControlState(DriveControlState.ROBOT_RELATIVE);
     SWERVE.ROTATION_PID_CONTROLLER.reset();
     SWERVE.ROTATION_PID_CONTROLLER.setTolerance(SWERVE.PIECE_TRACKING_ROTATION_TOLERANCE);
@@ -31,13 +31,13 @@ public class DriveToGamepeice extends Command {
 
   @Override
   public void execute() {
-    if (!m_canSeePieceDebouncer.calculate(Robot.shooterLimelight.validTargetExists())) {
+    if (!m_canSeePieceDebouncer.calculate(Robot.shooterPhotonCamera.validTargetExists())) {
       System.out.println("No Gamepiece Detected");
       Robot.swerve.drive(0, 0, 0);
       return;
     }
 
-    double rotationError = Robot.shooterLimelight.getTX();
+    double rotationError = Robot.shooterPhotonCamera.getTX();
     double rotationSpeed = SWERVE.ROTATION_PID_CONTROLLER.calculate(rotationError, 0);
     double translationSpeed =
         distanceTraveled() > SWERVE.PIECE_TRACKING_SLOW_DOWN_METERS

--- a/robotbase/src/main/java/frc/robot/commands/drive/DriveToGamepeice.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/DriveToGamepeice.java
@@ -14,12 +14,12 @@ public class DriveToGamepeice extends Command {
   private Pose2d m_initialPose;
 
   public DriveToGamepeice() {
-    addRequirements(Robot.swerve, Robot.shooterPhotonCamera);
+    addRequirements(Robot.swerve, Robot.shooterCam);
   }
 
   @Override
   public void initialize() {
-    Robot.shooterPhotonCamera.setPipeline(SHOOTER_LIMELIGHT.GAMEPIECE_INDEX);
+    Robot.shooterCam.setPipeline(SHOOTER_LIMELIGHT.GAMEPIECE_INDEX);
     Robot.state.setDriveControlState(DriveControlState.ROBOT_RELATIVE);
     SWERVE.ROTATION_PID_CONTROLLER.reset();
     SWERVE.ROTATION_PID_CONTROLLER.setTolerance(SWERVE.PIECE_TRACKING_ROTATION_TOLERANCE);
@@ -31,13 +31,13 @@ public class DriveToGamepeice extends Command {
 
   @Override
   public void execute() {
-    if (!m_canSeePieceDebouncer.calculate(Robot.shooterPhotonCamera.validTargetExists())) {
+    if (!m_canSeePieceDebouncer.calculate(Robot.shooterCam.validTargetExists())) {
       System.out.println("No Gamepiece Detected");
       Robot.swerve.drive(0, 0, 0);
       return;
     }
 
-    double rotationError = Robot.shooterPhotonCamera.getTX();
+    double rotationError = Robot.shooterCam.getTX();
     double rotationSpeed = SWERVE.ROTATION_PID_CONTROLLER.calculate(rotationError, 0);
     double translationSpeed =
         distanceTraveled() > SWERVE.PIECE_TRACKING_SLOW_DOWN_METERS

--- a/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
@@ -15,14 +15,14 @@ public class TargetLock extends Command {
   @Override
   public void initialize() {
     Robot.state.setDriveControlState(DriveControlState.TARGET_LOCK);
-    Robot.shooterLimelight.setPipeline(m_pipelineIndex);
+    Robot.shooterPhotonCamera.setPipeline(m_pipelineIndex);
     SWERVE.ROTATION_PID_CONTROLLER.reset();
   }
 
   @Override
   public void end(boolean interrupted) {
     Robot.state.setDriveControlState(DriveControlState.FIELD_RELATIVE);
-    Robot.shooterLimelight.setHumanPipelineActive();
+    Robot.shooterPhotonCamera.setHumanPipelineActive();
     SWERVE.ROTATION_PID_CONTROLLER.setP(SWERVE.ROTATION_KP);
   }
 }

--- a/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
@@ -22,7 +22,7 @@ public class TargetLock extends Command {
   @Override
   public void end(boolean interrupted) {
     Robot.state.setDriveControlState(DriveControlState.FIELD_RELATIVE);
-    Robot.shooterPhotonCamera.setHumanPipelineActive();
+    Robot.shooterPhotonCamera.setDriverModeActive();
     SWERVE.ROTATION_PID_CONTROLLER.setP(SWERVE.ROTATION_KP);
   }
 }

--- a/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
+++ b/robotbase/src/main/java/frc/robot/commands/drive/TargetLock.java
@@ -15,14 +15,14 @@ public class TargetLock extends Command {
   @Override
   public void initialize() {
     Robot.state.setDriveControlState(DriveControlState.TARGET_LOCK);
-    Robot.shooterPhotonCamera.setPipeline(m_pipelineIndex);
+    Robot.shooterCam.setPipeline(m_pipelineIndex);
     SWERVE.ROTATION_PID_CONTROLLER.reset();
   }
 
   @Override
   public void end(boolean interrupted) {
     Robot.state.setDriveControlState(DriveControlState.FIELD_RELATIVE);
-    Robot.shooterPhotonCamera.setDriverModeActive();
+    Robot.shooterCam.setDriverModeActive();
     SWERVE.ROTATION_PID_CONTROLLER.setP(SWERVE.ROTATION_KP);
   }
 }

--- a/robotbase/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -163,8 +163,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
   }
 
   public double getTargetLockRotation() {
-    double tx = Robot.shooterPhotonCamera.getTX();
-    if (!Robot.shooterPhotonCamera.validTargetExists()
+    double tx = Robot.shooterCam.getTX();
+    if (!Robot.shooterCam.validTargetExists()
         || Utility.isWithinTolerance(tx, 0, Constants.SWERVE.TARGET_LOCK_TOLERANCE)) {
       return 0;
     }

--- a/robotbase/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -163,8 +163,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
   }
 
   public double getTargetLockRotation() {
-    double tx = Robot.shooterLimelight.getTX();
-    if (!Robot.shooterLimelight.validTargetExists()
+    double tx = Robot.shooterPhotonCamera.getTX();
+    if (!Robot.shooterPhotonCamera.validTargetExists()
         || Utility.isWithinTolerance(tx, 0, Constants.SWERVE.TARGET_LOCK_TOLERANCE)) {
       return 0;
     }

--- a/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
@@ -1,0 +1,273 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems;
+
+import java.util.List;
+
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.networktables.DoubleArraySubscriber;
+import edu.wpi.first.networktables.DoubleArrayTopic;
+import edu.wpi.first.networktables.DoublePublisher;
+import edu.wpi.first.networktables.DoubleSubscriber;
+import edu.wpi.first.networktables.IntegerSubscriber;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.PHOTON_VISION;
+import frc.robot.Constants;
+
+/** Controls the limelight camera options. */
+public class PhotonVision extends SubsystemBase {
+
+  protected PhotonCamera m_camera;
+  private PhotonPipelineResult m_result;
+  private List<PhotonTrackedTarget> m_targets;
+  private PhotonPoseEstimator m_poseEstimator;
+  /**
+   * Sets the camera stream.
+   *
+   * @param cameraName Name of the cameras Photon Vision network table. MUST match the net tables name, or it wont work.
+   */
+  public PhotonVision(String cameraName) {
+    m_camera = new PhotonCamera(cameraName);
+  }
+
+  public void configure() {
+    setHumanPipelineActive();
+    m_poseEstimator = new PhotonPoseEstimator(PHOTON_VISION.APRIL_TAG_FIELD_LAYOUT, PHOTON_VISION.POSE_STRATEGY, m_camera, PHOTON_VISION.ROBOT_TO_CAMERA_TRANSFORM);
+    setStream(Constants.SHOOTER_LIMELIGHT.IS_PRIMARY_STREAM);
+  }
+
+  private void getResult(){
+    m_result = m_camera.getLatestResult();
+    m_targets = m_result.getTargets();
+  }
+
+  public boolean validTargetExists() {
+    return getTV();
+  }
+
+  
+  /**
+   * @return The current pipelines latency in milliseconds
+   */
+  public double getLatencyMillis(){
+    return m_result.getLatencyMillis();
+  }
+
+  /**
+   * @param id Id of the desired april tag
+   * @return If the limelight sees the april tag
+   */
+  public boolean validAprilTagTargetExists(int id) {
+    for(PhotonTrackedTarget target : m_targets){
+      if(target.getFiducialId() != -1){
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isHumanPipelineActive() {
+    return getPipeline() == Constants.SHOOTER_LIMELIGHT.HUMAN_PIPELINE_INDEX;
+  }
+
+  public void setPipeline(int index) {
+    m_camera.setDriverMode(false);
+    m_camera.setPipelineIndex(index);
+  }
+
+  public void setHumanPipelineActive() {
+    m_camera.setDriverMode(true);
+  }
+
+  public int getPipeline() {
+    return m_camera.getPipelineIndex();
+  }
+
+  public void setStream(boolean isLimelightPrimary) {
+    //TODO: Figure out if this has an equal in photon vision
+    //m_streamPub.set(isLimelightPrimary ? 1 : 2);
+  }
+
+  /**
+   * Whether the camera has a valid target
+   */
+  public boolean getTV() {
+    
+    return m_result.hasTargets();
+  }
+
+  /** Horizontal offset from crosshair to target (degrees) */
+  public double getTX() {
+    return m_targets.get(0).getYaw();
+  }
+
+  /** Vertical offset from crosshair to target (degrees) */
+  public double getTY() {
+    return m_targets.get(0).getPitch();
+  }
+
+  /** Percent of image covered by target [0, 100] */
+  public double getTA() {
+    return m_targets.get(0).getArea();
+  }
+
+  /** Skew or rotation (degrees, [-90, 0]) */
+  public double getTS() {
+    return m_targets.get(0).getSkew();
+  }
+
+  /** Horizontal sidelength of rough bounding box (0 - 320 pixels) */
+  public double getTHOR() {
+    return m_ThorSub.get();
+  }
+
+  /** Vertical sidelength of rough bounding box (0 - 320 pixels) */
+  public double getTVERT() {
+    return m_TvertSub.get();
+  }
+
+  /** Skew of target in degrees. Positive values are to the left, negative to the right */
+  public double getSkew() {
+    if (!validTargetExists()) {
+      return Double.NaN;
+    }
+
+    double ts = getTS();
+    if (ts < -45) {
+      return ts + 90;
+    } else {
+      return ts;
+    }
+  }
+
+  public boolean isHeadOn() {
+    if (!validTargetExists()) {
+      return false;
+    }
+
+    double skew = getSkew();
+    return (Constants.SHOOTER_LIMELIGHT.HEAD_ON_TOLERANCE <= skew
+        && skew <= Constants.SHOOTER_LIMELIGHT.HEAD_ON_TOLERANCE);
+  }
+
+  public boolean isToLeft() {
+    if (!validTargetExists()) {
+      return false;
+    }
+
+    return getSkew() > Constants.SHOOTER_LIMELIGHT.HEAD_ON_TOLERANCE;
+  }
+
+  public boolean isToRight() {
+    if (!validTargetExists()) {
+      return false;
+    }
+
+    return getSkew() < Constants.SHOOTER_LIMELIGHT.HEAD_ON_TOLERANCE;
+  }
+
+  public double getTargetRotationDegrees() {
+    if (!validTargetExists()) {
+      return Double.NaN;
+    }
+
+    if (isHeadOn()) {
+      return 0.0;
+    } else if (isToLeft()) {
+      return -getRotationAngle();
+    } else {
+      return getRotationAngle();
+    }
+  }
+
+  private double getRotationAngle() {
+    if (!validTargetExists()) {
+      return Double.NaN;
+    }
+
+    double proportion = getTHOR() / getTVERT();
+    double factor =
+        proportion
+            * Constants.SHOOTER_LIMELIGHT.TARGET_HEIGHT
+            / Constants.SHOOTER_LIMELIGHT.TARGET_WIDTH;
+    return 90.0 * (1 - factor);
+  }
+
+  public double getInchesFromTarget() {
+    if (!validTargetExists()) {
+      return Double.NaN;
+    }
+
+    double angleDegrees = Math.abs(getTY()) + Constants.SHOOTER_LIMELIGHT.MOUNTING_ANGLE_DEGREES;
+
+    double heightDifference =
+        Constants.SHOOTER_LIMELIGHT.MOUNTING_HEIGHT_INCHES
+            - Constants.SHOOTER_LIMELIGHT.TARGET_HEIGHT_FROM_FLOOR;
+    double distance = heightDifference / Math.tan(Math.toRadians(angleDegrees));
+
+    return distance;
+  }
+
+  public Pose2d getLimelightPose2d() {
+    return botposeToPose2d(m_limelightPoseInfoSub.get());
+  }
+
+  public Long getLastTargetID() {
+    return m_Tid.get();
+  }
+
+  public Pose2d getRedPose() {
+    return m_camera.get
+  }
+
+  public Pose2d getBluePose() {
+    return botposeToPose2d(m_botposeWpiBlue.get());
+  }
+
+  public double getBlueBotposeTimestamp() {
+    return calculateTimestamp(m_botposeWpiBlue.get());
+  }
+
+  public double getRedBotposeTimestamp() {
+    return calculateTimestamp(m_botposeWpiRed.get());
+  }
+
+  public double calculateTimestamp(double[] botpose) {
+    if (botpose == null) {
+      return 0;
+    }
+
+    return Timer.getFPGATimestamp() - (botpose[6] / 1000);
+  }
+
+  public static Pose2d botposeToPose2d(double[] botpose) {
+    if (botpose == null) {
+      return null;
+    }
+
+    Translation2d t2d = new Translation2d(botpose[0], botpose[1]);
+    Rotation2d r2d = Rotation2d.fromDegrees(botpose[5]);
+    return new Pose2d(t2d, r2d);
+  }
+
+  @Override
+  public void periodic() {
+    getResult();
+  }
+}

--- a/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
@@ -7,11 +7,12 @@
 
 package frc.robot.subsystems;
 
+import static frc.robot.Constants.PHOTON_VISION;
+
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import static frc.robot.Constants.PHOTON_VISION;
 import java.util.List;
 import java.util.Optional;
 import org.photonvision.EstimatedRobotPose;
@@ -25,14 +26,15 @@ import org.photonvision.targeting.TargetCorner;
 /** Controls the limelight camera options. */
 public class PhotonVision extends SubsystemBase {
 
-  //all of these are protected so we can use them in the extended classes
-  //which are only extended so we can control which pipelines we are using.
+  // all of these are protected so we can use them in the extended classes
+  // which are only extended so we can control which pipelines we are using.
   protected PhotonCamera m_camera;
   protected PhotonPipelineResult m_result;
   protected List<PhotonTrackedTarget> m_targets;
   protected PhotonTrackedTarget m_bestTarget;
   protected PhotonPoseEstimator m_poseEstimator;
-  protected final Transform3d m_ROBOT_TO_CAMERA_TRANSFORM; //if this changes, we have bigger issues.
+  protected final Transform3d
+      m_ROBOT_TO_CAMERA_TRANSFORM; // if this changes, we have bigger issues.
   protected final double m_HEAD_ON_TOLERANCE;
 
   /**
@@ -41,7 +43,8 @@ public class PhotonVision extends SubsystemBase {
    * @param cameraName Name of the cameras Photon Vision network table. MUST match the net tables
    *     name, or it wont work.
    */
-  public PhotonVision(String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
+  public PhotonVision(
+      String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
     m_camera = new PhotonCamera(cameraName);
     m_ROBOT_TO_CAMERA_TRANSFORM = robotToCameraTransform;
     m_HEAD_ON_TOLERANCE = headOnTolerance;
@@ -58,10 +61,12 @@ public class PhotonVision extends SubsystemBase {
   }
 
   /**
-   * Fetches the latest pipeline result.<p>
-   * YOU SHOULD NEVER CALL THIS! This is for the Robot periodic ONLY. NEVER call this method outside of it.s
+   * Fetches the latest pipeline result.
+   *
+   * <p>YOU SHOULD NEVER CALL THIS! This is for the Robot periodic ONLY. NEVER call this method
+   * outside of it.s
    */
-  public void fetchResult(){
+  public void updateResult() {
     m_result = m_camera.getLatestResult();
     m_targets = m_result.getTargets();
     m_bestTarget = m_result.getBestTarget();
@@ -99,11 +104,11 @@ public class PhotonVision extends SubsystemBase {
     m_camera.setDriverMode(true);
   }
 
-  public void toggleDriverMode(){
+  public void toggleDriverMode() {
     m_camera.setDriverMode(!m_camera.getDriverMode());
   }
 
-  public void setDriverModeDisabled(){
+  public void setDriverModeDisabled() {
     m_camera.setDriverMode(false);
   }
 
@@ -111,8 +116,6 @@ public class PhotonVision extends SubsystemBase {
     m_camera.setDriverMode(false);
     m_camera.setPipelineIndex(index);
   }
-
-  
 
   public int getPipeline() {
     return m_camera.getPipelineIndex();
@@ -230,8 +233,10 @@ public class PhotonVision extends SubsystemBase {
     return m_bestTarget.getSkew();
   }
 
-  /** Yaw of target in degrees. Positive values are to the left, negative to the right.<p>
-   * The "getSkew()" equivalent in PhotonVision.
+  /**
+   * Yaw of target in degrees. Positive values are to the left, negative to the right.
+   *
+   * <p>The "getSkew()" equivalent in PhotonVision.
    */
   public double getFilteredYaw() {
     if (!validTargetExists()) {
@@ -252,8 +257,7 @@ public class PhotonVision extends SubsystemBase {
     }
 
     double skew = getYaw();
-    return (m_HEAD_ON_TOLERANCE <= skew
-        && skew <= m_HEAD_ON_TOLERANCE);
+    return (m_HEAD_ON_TOLERANCE <= skew && skew <= m_HEAD_ON_TOLERANCE);
   }
 
   public boolean isToLeft() {
@@ -332,16 +336,15 @@ public class PhotonVision extends SubsystemBase {
     List<PhotonTrackedTarget> filteredTargets = m_targets;
     for (int i = 0; i < m_targets.size(); i++) {
       boolean removeTag = true;
-      for(int targetIDWanted : tagsToFilterFor){
-        if(filteredTargets.get(i).getFiducialId() == targetIDWanted){
+      for (int targetIDWanted : tagsToFilterFor) {
+        if (filteredTargets.get(i).getFiducialId() == targetIDWanted) {
           removeTag = false;
         }
       }
-      if(removeTag){
+      if (removeTag) {
         filteredTargets.remove(i);
       }
     }
     return filteredTargets;
   }
-
 }

--- a/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/PhotonVision.java
@@ -33,9 +33,8 @@ public class PhotonVision extends SubsystemBase {
   protected List<PhotonTrackedTarget> m_targets;
   protected PhotonTrackedTarget m_bestTarget;
   protected PhotonPoseEstimator m_poseEstimator;
-  protected final Transform3d
-      m_ROBOT_TO_CAMERA_TRANSFORM; // if this changes, we have bigger issues.
-  protected final double m_HEAD_ON_TOLERANCE;
+  protected final Transform3d ROBOT_TO_CAMERA_TRANSFORM; // if this changes, we have bigger issues.
+  protected final double HEAD_ON_TOLERANCE;
 
   /**
    * Sets the camera stream.
@@ -46,8 +45,8 @@ public class PhotonVision extends SubsystemBase {
   public PhotonVision(
       String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
     m_camera = new PhotonCamera(cameraName);
-    m_ROBOT_TO_CAMERA_TRANSFORM = robotToCameraTransform;
-    m_HEAD_ON_TOLERANCE = headOnTolerance;
+    ROBOT_TO_CAMERA_TRANSFORM = robotToCameraTransform;
+    HEAD_ON_TOLERANCE = headOnTolerance;
   }
 
   public void configure() {
@@ -57,7 +56,7 @@ public class PhotonVision extends SubsystemBase {
             PHOTON_VISION.APRIL_TAG_FIELD_LAYOUT,
             PHOTON_VISION.POSE_STRATEGY,
             m_camera,
-            m_ROBOT_TO_CAMERA_TRANSFORM);
+            ROBOT_TO_CAMERA_TRANSFORM);
   }
 
   /**
@@ -257,7 +256,7 @@ public class PhotonVision extends SubsystemBase {
     }
 
     double skew = getYaw();
-    return (m_HEAD_ON_TOLERANCE <= skew && skew <= m_HEAD_ON_TOLERANCE);
+    return (HEAD_ON_TOLERANCE <= skew && skew <= HEAD_ON_TOLERANCE);
   }
 
   public boolean isToLeft() {
@@ -265,7 +264,7 @@ public class PhotonVision extends SubsystemBase {
       return false;
     }
 
-    return getFilteredYaw() > m_HEAD_ON_TOLERANCE;
+    return getFilteredYaw() > HEAD_ON_TOLERANCE;
   }
 
   public boolean isToRight() {
@@ -273,7 +272,7 @@ public class PhotonVision extends SubsystemBase {
       return false;
     }
 
-    return getFilteredYaw() < m_HEAD_ON_TOLERANCE;
+    return getFilteredYaw() < HEAD_ON_TOLERANCE;
   }
 
   public double getTargetRotationDegrees() {

--- a/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
@@ -93,7 +93,7 @@ public class Shooter extends SubsystemBase {
   }
 
   public boolean hasTarget() {
-    return Robot.shooterPhotonCamera.validTargetExists();
+    return Robot.shooterCam.validTargetExists();
   }
 
   @Override
@@ -105,17 +105,17 @@ public class Shooter extends SubsystemBase {
 
   public void startVisionShooting() {
     m_isClosedLoopEnabled = true;
-    Robot.shooterPhotonCamera.setPipeline(Constants.SHOOTER_LIMELIGHT.SPEAKER_PIPELINE_INDEX);
+    Robot.shooterCam.setPipeline(Constants.SHOOTER_LIMELIGHT.SPEAKER_PIPELINE_INDEX);
   }
 
   public void endVisionShooting() {
     m_isClosedLoopEnabled = false;
-    Robot.shooterPhotonCamera.setDriverModeActive();
+    Robot.shooterCam.setDriverModeActive();
   }
 
   private void visionShotPeriodic() {
     if (hasTarget()) {
-      setVisionShotRPMs(Robot.shooterPhotonCamera.getTY());
+      setVisionShotRPMs(Robot.shooterCam.getTY());
     } else {
       System.err.println("----- No vision target -----");
     }

--- a/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
@@ -110,7 +110,7 @@ public class Shooter extends SubsystemBase {
 
   public void endVisionShooting() {
     m_isClosedLoopEnabled = false;
-    Robot.shooterPhotonCamera.setHumanPipelineActive();
+    Robot.shooterPhotonCamera.setDriverModeActive();
   }
 
   private void visionShotPeriodic() {

--- a/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/Shooter.java
@@ -93,7 +93,7 @@ public class Shooter extends SubsystemBase {
   }
 
   public boolean hasTarget() {
-    return Robot.shooterLimelight.validTargetExists();
+    return Robot.shooterPhotonCamera.validTargetExists();
   }
 
   @Override
@@ -105,17 +105,17 @@ public class Shooter extends SubsystemBase {
 
   public void startVisionShooting() {
     m_isClosedLoopEnabled = true;
-    Robot.shooterLimelight.setPipeline(Constants.SHOOTER_LIMELIGHT.SPEAKER_PIPELINE_INDEX);
+    Robot.shooterPhotonCamera.setPipeline(Constants.SHOOTER_LIMELIGHT.SPEAKER_PIPELINE_INDEX);
   }
 
   public void endVisionShooting() {
     m_isClosedLoopEnabled = false;
-    Robot.shooterLimelight.setHumanPipelineActive();
+    Robot.shooterPhotonCamera.setHumanPipelineActive();
   }
 
   private void visionShotPeriodic() {
     if (hasTarget()) {
-      setVisionShotRPMs(Robot.shooterLimelight.getTY());
+      setVisionShotRPMs(Robot.shooterPhotonCamera.getTY());
     } else {
       System.err.println("----- No vision target -----");
     }

--- a/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
@@ -9,7 +9,7 @@ public class ShooterPhotonCamera extends PhotonVision {
   /**
    * An extension of the PhotonVision class that has the pipelines for the shooter photon camera
    * implimented. Uses the PhotonVision classes method to set the pipeline, so we set them
-   * consistantly.
+   * consistently.
    */
   public ShooterPhotonCamera(
       String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {

--- a/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
@@ -1,33 +1,34 @@
 package frc.robot.subsystems;
 
-import edu.wpi.first.math.geometry.Transform3d;
 import static frc.robot.Constants.SHOOTER_PHOTON_CAMERA;
 
-public class ShooterPhotonCamera extends PhotonVision{
+import edu.wpi.first.math.geometry.Transform3d;
 
-    /**
-     * An extension of the PhotonVision class that has the pipelines for the shooter photon camera implimented.
-     * Uses the PhotonVision classes method to set the pipeline, so we set them consistantly.
-     */
-    public ShooterPhotonCamera(String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
-        super(cameraName, robotToCameraTransform, headOnTolerance);
+public class ShooterPhotonCamera extends PhotonVision {
 
-    }
+  /**
+   * An extension of the PhotonVision class that has the pipelines for the shooter photon camera
+   * implimented. Uses the PhotonVision classes method to set the pipeline, so we set them
+   * consistantly.
+   */
+  public ShooterPhotonCamera(
+      String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
+    super(cameraName, robotToCameraTransform, headOnTolerance);
+  }
 
-    public void setNeuralNetworkPipelineActive(){
-        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
-    }
+  public void setNeuralNetworkPipelineActive() {
+    super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+  }
 
-    public void setRetroReflectivePipelineActive(){
-        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
-    }
+  public void setRetroReflectivePipelineActive() {
+    super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+  }
 
-    public void setAprilTagPipelineActive(){
-        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
-    }
+  public void setAprilTagPipelineActive() {
+    super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+  }
 
-    public void setDefaultPipelineActive(){
-        super.setPipeline(SHOOTER_PHOTON_CAMERA.DEFAULT_PIPELINE);
-    }
-    
+  public void setDefaultPipelineActive() {
+    super.setPipeline(SHOOTER_PHOTON_CAMERA.DEFAULT_PIPELINE);
+  }
 }

--- a/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
+++ b/robotbase/src/main/java/frc/robot/subsystems/ShooterPhotonCamera.java
@@ -1,0 +1,33 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.math.geometry.Transform3d;
+import static frc.robot.Constants.SHOOTER_PHOTON_CAMERA;
+
+public class ShooterPhotonCamera extends PhotonVision{
+
+    /**
+     * An extension of the PhotonVision class that has the pipelines for the shooter photon camera implimented.
+     * Uses the PhotonVision classes method to set the pipeline, so we set them consistantly.
+     */
+    public ShooterPhotonCamera(String cameraName, Transform3d robotToCameraTransform, double headOnTolerance) {
+        super(cameraName, robotToCameraTransform, headOnTolerance);
+
+    }
+
+    public void setNeuralNetworkPipelineActive(){
+        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+    }
+
+    public void setRetroReflectivePipelineActive(){
+        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+    }
+
+    public void setAprilTagPipelineActive(){
+        super.setPipeline(SHOOTER_PHOTON_CAMERA.NEURAL_NETWORK_PIPELINE);
+    }
+
+    public void setDefaultPipelineActive(){
+        super.setPipeline(SHOOTER_PHOTON_CAMERA.DEFAULT_PIPELINE);
+    }
+    
+}

--- a/robotbase/vendordeps/ChoreoLib.json
+++ b/robotbase/vendordeps/ChoreoLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "ChoreoLib.json",
     "name": "ChoreoLib",
-    "version": "2024.1.2",
+    "version": "2024.1.3",
     "uuid": "287cff6e-1b60-4412-8059-f6834fb30e30",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.choreo.lib",
             "artifactId": "ChoreoLib-java",
-            "version": "2024.1.2"
+            "version": "2024.1.3"
         },
         {
             "groupId": "com.google.code.gson",
@@ -25,7 +25,7 @@
         {
             "groupId": "com.choreo.lib",
             "artifactId": "ChoreoLib-cpp",
-            "version": "2024.1.2",
+            "version": "2024.1.3",
             "libName": "ChoreoLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/robotbase/vendordeps/Phoenix6.json
+++ b/robotbase/vendordeps/Phoenix6.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.1.0",
+    "version": "24.2.0",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.1.0"
+            "version": "24.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/robotbase/vendordeps/REVLib.json
+++ b/robotbase/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.2.0",
+    "version": "2024.2.1",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.2.0"
+            "version": "2024.2.1"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.0",
+            "version": "2024.2.1",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.2.0",
+            "version": "2024.2.1",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.0",
+            "version": "2024.2.1",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/robotbase/vendordeps/photonlib.json
+++ b/robotbase/vendordeps/photonlib.json
@@ -1,0 +1,57 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2024.2.4",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
+    "frcYear": "2024",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-cpp",
+            "version": "v2024.2.4",
+            "libName": "photonlib",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-cpp",
+            "version": "v2024.2.4",
+            "libName": "photontargeting",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-java",
+            "version": "v2024.2.4"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-java",
+            "version": "v2024.2.4"
+        }
+    ]
+}


### PR DESCRIPTION
added the Photon Vision subsystem, made it use a result-based approach, so we don't have to deal with subscribing to network tables or anything like that. Basically, every loop we need to call getResult() for each of the cameras as the first thing we do, so we need their periodic's to be called first, or we risk some subsystems using outdated data. getResult() just makes PhotonLib send us the pipelines result, so we are still using some network tables, but just one subscriber per camera, and that's the library's subscriber.